### PR TITLE
[ LLM did this ]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScopeDisabled"
+  ]
+}


### PR DESCRIPTION
Configure Renovate to use 'chore:' prefix for all PRs instead of 'fix:' for production dependencies.

Changes:
- Use  to force all PRs to use 'chore:' prefix
- Use  to remove the scope (deps, devDeps, etc.) from PR titles

Result: PR titles will be 'chore: update dependency ...' instead of 'chore(deps): update dependency ...' or 'fix(deps): update dependency ...'

Closes #1